### PR TITLE
change mask size

### DIFF
--- a/isaac_ros_foundationpose/launch/isaac_ros_foundationpose_melon_sim.launch.py
+++ b/isaac_ros_foundationpose/launch/isaac_ros_foundationpose_melon_sim.launch.py
@@ -417,8 +417,8 @@ def generate_launch_description():
             # ('pose_estimation/depth_image', '/depth_image'),
             ('pose_estimation/image', '/rgb/image_rect_color'),
             ('pose_estimation/camera_info', '/rgb/camera_info'),
-            ('pose_estimation/segmentation', 'segmentation'),
-            ('pose_estimation/output', '/rgb/output')
+            ('pose_estimation/segmentation', 'segmentation')
+            # ('pose_estimation/output', '/rgb/output')
 
         ]
     )

--- a/isaac_ros_foundationpose/src/detection2_d_to_mask.cpp
+++ b/isaac_ros_foundationpose/src/detection2_d_to_mask.cpp
@@ -45,8 +45,8 @@ public:
   : Node("detection2_d_to_mask", options),
     input_qos_{::isaac_ros::common::AddQosParameter(*this, "DEFAULT", "input_qos")},
     output_qos_{::isaac_ros::common::AddQosParameter(*this, "DEFAULT", "output_qos")},
-    mask_width_(declare_parameter<int>("mask_width", 640)),
-    mask_height_(declare_parameter<int>("mask_height", 480)),
+    mask_width_(declare_parameter<int>("mask_width", 1280)),
+    mask_height_(declare_parameter<int>("mask_height", 720)),
     image_pub_{create_publisher<sensor_msgs::msg::Image>("segmentation", output_qos_)},
     detection2_d_sub_{create_subscription<vision_msgs::msg::Detection2D>(
         "detection2_d", input_qos_,


### PR DESCRIPTION
FoundationPoseのmask画像のサイズをIsaacSimの画像トピックのサイズと同じにしました。
FoundationPoseの出力トピック名をデフォルトのものに戻しました